### PR TITLE
Better handling of CMakeLists variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,8 @@ project(MLSdkForVulkan
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-if(ML_SDK_GENERATE_CPACK STREQUAL "TRUE")
-    set(ML_SDK_GENERATE_CPACK TRUE CACHE BOOL "Generate CPack artifacts")
-else()
-    set(ML_SDK_GENERATE_CPACK FALSE CACHE BOOL "Generate CPack artifacts")
-endif()
+option(ML_SDK_GENERATE_CPACK "Generate CPack artifacts" OFF)
+
 list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_LIST_DIR}/cmake
 )


### PR DESCRIPTION
Updated handling of build variable using option, instead of set

Change-Id: Ic35ed260dbfcf8723f26656d5b2b4f2d2a5b50c4