### PR TITLE
Rework toolchain files to support more platforms

### DIFF
--- a/cmake/toolchain/clang.cmake
+++ b/cmake/toolchain/clang.cmake
@@ -1,0 +1,35 @@
+#
+# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(CMAKE_CROSSCOMPILING OFF)
+
+find_program(CLANG_PATH clang)
+if(NOT CLANG_PATH)
+    message(FATAL_ERROR "clang not found")
+endif()
+
+find_program(CLANGXX_PATH clang++)
+if(NOT CLANGXX_PATH)
+    message(FATAL_ERROR "clang++ not found")
+endif()
+
+# Set the compilers
+set(CMAKE_C_COMPILER "${CLANG_PATH}" CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER "${CLANGXX_PATH}" CACHE FILEPATH "C++ compiler")
+
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++")
+
+# Use lld if available
+if(UNIX AND NOT APPLE)
+    find_program(LLD lld)
+    if(LLD)
+        message(STATUS "Using lld linker with Clang")
+        set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+    else()
+        message(WARNING "lld not found, using system default linker")
+    endif()
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/gnu_compiler_options.cmake)

--- a/cmake/toolchain/gcc.cmake
+++ b/cmake/toolchain/gcc.cmake
@@ -1,0 +1,21 @@
+#
+# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set(CMAKE_CROSSCOMPILING OFF)
+
+find_program(GCC_PATH gcc)
+if(NOT GCC_PATH)
+    message(FATAL_ERROR "gcc not found")
+endif()
+
+find_program(GPP_PATH g++)
+if(NOT GPP_PATH)
+    message(FATAL_ERROR "g++ not found")
+endif()
+
+set(CMAKE_C_COMPILER "${GCC_PATH}" CACHE FILEPATH "C compiler")
+set(CMAKE_CXX_COMPILER "${GPP_PATH}" CACHE FILEPATH "C++ compiler")
+
+include(${CMAKE_CURRENT_LIST_DIR}/gnu_compiler_options.cmake)

--- a/cmake/toolchain/gnu_compiler_options.cmake
+++ b/cmake/toolchain/gnu_compiler_options.cmake
@@ -1,0 +1,20 @@
+#
+# SPDX-FileCopyrightText: Copyright 2023-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Compilation warnings
+set(ML_SDK_SCENARIO_RUNNER_COMPILE_OPTIONS -Werror -Wall -Wextra -Wsign-conversion -Wconversion -Wpedantic)
+
+if(SCENARIO_RUNNER_GCC_SANITIZERS)
+    message(STATUS "GCC Sanitizers enabled")
+    add_compile_options(
+        -fsanitize=undefined,address
+        -fno-sanitize=vptr,alignment
+        -fno-sanitize-recover=all
+    )
+    add_link_options(
+        -fsanitize=undefined,address
+    )
+    unset(SCENARIO_RUNNER_GCC_SANITIZERS CACHE)
+endif()

--- a/cmake/toolchain/windows-msvc.cmake
+++ b/cmake/toolchain/windows-msvc.cmake
@@ -1,0 +1,7 @@
+#
+# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Compilation warnings
+set(ML_SDK_SCENARIO_RUNNER_COMPILE_OPTIONS /EHa /WX /W4)


### PR DESCRIPTION
Toolchains clang.cmake and gcc.cmake should work on multiple hosts

clang.cmake should be default on Darwin-based systems

New option in build.py to use Clang for building on a Linux host

Change-Id: I33f61d3f2c89280295798ebc770d6d56a25b4680