### PR TITLE
Fix docs generation using Clang

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,4 +83,9 @@ html_css_files = [
 # Enable RTD theme
 html_theme = "sphinx_rtd_theme"
 
-exclude_patterns = ["**/glslang/**", "**/dependencies/**"]
+exclude_patterns = [
+    "**/glslang/**",
+    "**/dependencies/**",
+    "**/docs/generated/*.md",
+    "**/generated/*.md",
+]


### PR DESCRIPTION
Build process would crash when docs were generated using Clang

Change-Id: Iba58a06e8f99d2d46dd30ab47eba194e344a7ea7