### PR TITLE
Removing remnant wrong gcc sanitizer checks from sdk root

### DIFF
--- a/cmake/toolchain/gnu_compiler_options.cmake
+++ b/cmake/toolchain/gnu_compiler_options.cmake
@@ -5,16 +5,3 @@
 
 # Compilation warnings
 set(ML_SDK_SCENARIO_RUNNER_COMPILE_OPTIONS -Werror -Wall -Wextra -Wsign-conversion -Wconversion -Wpedantic)
-
-if(SCENARIO_RUNNER_GCC_SANITIZERS)
-    message(STATUS "GCC Sanitizers enabled")
-    add_compile_options(
-        -fsanitize=undefined,address
-        -fno-sanitize=vptr,alignment
-        -fno-sanitize-recover=all
-    )
-    add_link_options(
-        -fsanitize=undefined,address
-    )
-    unset(SCENARIO_RUNNER_GCC_SANITIZERS CACHE)
-endif()


### PR DESCRIPTION
Change-Id: I8ad68d660aa65938548d8b4b065b94f82932516f