### PR TITLE
macOS CI remove link to /usr/local/lib/libvulkan.dylib

### DIFF
--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -108,8 +108,6 @@ jobs:
         run: |
           brew install molten-vk vulkan-tools vulkan-headers vulkan-loader
           echo "VK_DRIVER_FILES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json" >> $GITHUB_ENV
-          sudo mkdir -p /usr/local/lib
-          sudo ln -s /opt/homebrew/lib/libvulkan.dylib /usr/local/lib/libvulkan.dylib
 
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh


### PR DESCRIPTION
see https://github.com/arm/ai-ml-sdk-for-vulkan/issues/99

Waiting for `dependencies/Vulkan-Headers` to update to `v1.4.337` or latter 

