### PR TITLE
Remove manual signed-off-by checker from github workflows

### DIFF
--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -109,7 +109,6 @@ fi
 run_checks() {
   pushd "${1}"
   echo "Current commit: $(git rev-parse HEAD)"
-  git show -s --format=%B HEAD | grep "Signed-off-by:"
   pre-commit run --all-files --hook-stage commit --show-diff-on-failure
   pre-commit run --all-files --hook-stage push --show-diff-on-failure
   popd


### PR DESCRIPTION
This is now enforced at another level.