### PR TITLE
Set SDK CPack version from release builds

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-FileCopyrightText: Copyright 2025-2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 
@@ -16,24 +16,34 @@ macro(mlsdk_package)
     set(CPACK_PACKAGE_VERSION "none")
     set(GIT_UNTRACKED_FILES "")
 
-    find_package(Git)
+    if(DEFINED ML_SDK_PACKAGE_VERSION AND NOT "${ML_SDK_PACKAGE_VERSION}" STREQUAL "")
+        if(NOT "${ML_SDK_PACKAGE_VERSION}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+            message(FATAL_ERROR "ML_SDK_PACKAGE_VERSION must start with major.minor.patch, got '${ML_SDK_PACKAGE_VERSION}'")
+        endif()
+        set(CPACK_PACKAGE_VERSION "${ML_SDK_PACKAGE_VERSION}")
+        set(CPACK_PACKAGE_VERSION_MAJOR ${CMAKE_MATCH_1})
+        set(CPACK_PACKAGE_VERSION_MINOR ${CMAKE_MATCH_2})
+        set(CPACK_PACKAGE_VERSION_PATCH ${CMAKE_MATCH_3})
+    else()
+        find_package(Git)
 
-    if(Git_FOUND)
-        execute_process(
-            COMMAND ${GIT_EXECUTABLE} describe --long --match=[0-9][0-9].[0-9][0-9]
-            WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
-            RESULT_VARIABLE RESULT
-            OUTPUT_VARIABLE GIT_DESCRIBE
-            ERROR_QUIET
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(Git_FOUND)
+            execute_process(
+                COMMAND ${GIT_EXECUTABLE} describe --long --match=[0-9][0-9].[0-9][0-9]
+                WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+                RESULT_VARIABLE RESULT
+                OUTPUT_VARIABLE GIT_DESCRIBE
+                ERROR_QUIET
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-        if(RESULT EQUAL "0")
-            # Transform output from 24.08-16-g00d8931 to 24.08.16.g00d8931
-            string(REGEX MATCH "^([0-9]+).([0-9]+)-([0-9]+)-([a-z0-9]+)" TMP ${GIT_DESCRIBE})
-            set(CPACK_PACKAGE_VERSION_MAJOR ${CMAKE_MATCH_1})
-            set(CPACK_PACKAGE_VERSION_MINOR ${CMAKE_MATCH_2})
-            set(CPACK_PACKAGE_VERSION_PATCH "${CMAKE_MATCH_3}.${CMAKE_MATCH_4}")
-            set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+            if(RESULT EQUAL "0")
+                # Transform output from 24.08-16-g00d8931 to 24.08.16.g00d8931
+                string(REGEX MATCH "^([0-9]+).([0-9]+)-([0-9]+)-([a-z0-9]+)" TMP ${GIT_DESCRIBE})
+                set(CPACK_PACKAGE_VERSION_MAJOR ${CMAKE_MATCH_1})
+                set(CPACK_PACKAGE_VERSION_MINOR ${CMAKE_MATCH_2})
+                set(CPACK_PACKAGE_VERSION_PATCH "${CMAKE_MATCH_3}.${CMAKE_MATCH_4}")
+                set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+            endif()
         endif()
     endif()
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -63,6 +63,7 @@ class Builder:
         self.package_dir = args.package_dir or self.build_dir
         self.package_tgz = "tgz" in args.package_type
         self.package_zip = "zip" in args.package_type
+        self.package_version = args.package_version
 
     def setup_platform_build(self, cmake_setup_cmd):
         system = platform.system()
@@ -150,6 +151,9 @@ class Builder:
 
         if self.install or self.package_tgz or self.package_zip:
             cmake_setup_cmd.append(f"-DML_SDK_GENERATE_CPACK=ON")
+
+        if self.package_version:
+            cmake_setup_cmd.append(f"-DML_SDK_PACKAGE_VERSION={self.package_version}")
 
         if self.skip_llvm_patch or self.doc_only:
             cmake_setup_cmd.append("-DMODEL_CONVERTER_APPLY_LLVM_PATCH=OFF")
@@ -351,6 +355,11 @@ def parse_arguments():
         action="append",
         help="Create a package of a certain type",
         default=[],
+    )
+    parser.add_argument(
+        "--package-version",
+        help="Manually specify package version number",
+        default="",
     )
     parser.add_argument(
         "--enable-hlsl-support",


### PR DESCRIPTION
Allow the SDK build wrapper to pass an explicit package version to CMake and use that value for CPack metadata

Change-Id: I82a57711e59221e2942355c2bbbd3abe6bfd7a8e