### PR TITLE
Enable compiler caching for SDK build on Linux, MacOS, and Windows

### DIFF
--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -72,6 +72,19 @@ jobs:
 
       - &checkout
         uses: actions/checkout@v6
+
+      - name: Install cchace
+        run: |
+          sudo apt-get ccache
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh
 
@@ -108,6 +121,16 @@ jobs:
         run: |
           brew install molten-vk vulkan-tools vulkan-headers vulkan-loader
           echo "VK_DRIVER_FILES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json" >> $GITHUB_ENV
+
+      - name: Install ccache
+        run: brew install ccache
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh
@@ -158,6 +181,20 @@ jobs:
         shell: pwsh
         run: |
           git clone https://gerrit.googlesource.com/git-repo
+
+      - name: Install sccache # https://github.com/mozilla/sccache
+        shell: pwsh
+        run: |
+          choco install -y sccache
+          sccache --version
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\Mozilla\sccache
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            sccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run CI build script
         shell: pwsh

--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -73,14 +73,10 @@ jobs:
       - &checkout
         uses: actions/checkout@v6
 
-      - name: Install cchace
-        run: |
-          sudo apt-get ccache
-
-      - name: Cache ccache
+      - name: Cache sccache
         uses: actions/cache@v4
         with:
-          path: ~/.cache/ccache
+          path: /home/$user/.local/bin/sccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/scripts/ci_build.ps1
+++ b/.github/workflows/scripts/ci_build.ps1
@@ -142,6 +142,13 @@ try {
 
     $env:VK_INSTANCE_LAYERS = "VK_LAYER_ML_Graph_Emulation;VK_LAYER_ML_Tensor_Emulation"
 
+    # Set the sccache cache directory (matches the GitHub Actions cache path)
+    $env:SCCACHE_DIR = "$env:LOCALAPPDATA\Mozilla\sccache"
+    $env:CMAKE_C_COMPILER_LAUNCHER = "sccache"
+    $env:CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
+
+    sccache --zero-stats || $true
+
     Write-Host "Build VGF-Lib"
     python "./sw/vgf-lib/scripts/build.py" -j $cores --test
 
@@ -156,6 +163,8 @@ try {
 
     Write-Host "Build SDK Root"
     python "./scripts/build.py" -j $cores
+
+    sccache --show-stats || $true
 }
 finally {
     Pop-Location

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -114,6 +114,19 @@ run_checks() {
   popd
 }
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  export CCACHE_DIR="$HOME/Library/Caches/ccache"
+else
+  export CCACHE_DIR="$HOME/.cache/ccache"
+fi
+
+mkdir -p "$CCACHE_DIR"
+
+export CMAKE_C_COMPILER_LAUNCHER=ccache
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+ccache --zero-stats || true
+
 echo "Build VGF-Lib"
 run_checks ./sw/vgf-lib
 ./sw/vgf-lib/scripts/build.py -j $(nproc) --doc --test
@@ -137,5 +150,7 @@ run_checks ./sw/scenario-runner
 echo "Build SDK Root"
 run_checks .
 ./scripts/build.py -j $(nproc) --doc
+
+ccache --show-stats || true
 
 popd

--- a/docs/source/e2e_onnx_tutorial.rst
+++ b/docs/source/e2e_onnx_tutorial.rst
@@ -4,11 +4,12 @@ Converting and deploying an ONNX model tutorial
 This tutorial demonstrates how to convert and deploy an ONNX model using Torch-MLIR and the ML SDK for Vulkan®.
 It walks through model conversion to TOSA MLIR, VGF file generation, and execution using the ML SDK Scenario Runner.
 
-1. Install Torch-MLIR
+1. Install Torch-MLIR and ONNX
 
 .. code-block:: bash
 
     pip install --pre torch-mlir -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
+    pip install onnx
 
 2. Download the ONNX Model:
 
@@ -21,7 +22,7 @@ It walks through model conversion to TOSA MLIR, VGF file generation, and executi
 .. code-block:: python
 
     import numpy
-    data = numpy.random.rand(28,28).astype(numpy.float32)
+    data = numpy.random.rand(1,1,28,28).astype(numpy.float32)
     numpy.save("input-0.npy", data)
 
 4. Convert the Model to TOSA MLIR Bytecode:

--- a/docs/source/vgf_run_tutorial.rst
+++ b/docs/source/vgf_run_tutorial.rst
@@ -25,7 +25,10 @@ you must have a scenario specification in the form of a JSON file:
     :ref:`JSON Test Description Specification`.
 
 
-3. Run the ML SDK Scenario Runner on the ML Emulation Layer for Vulkan®:
+3. Set up the ML Emulation Layer for Vulkan® on your system, see: :ref:`ML Emulation Layer for Vulkan® Usage <ml-emulation-layer-vulkan-usage>`
+
+
+4. Run the ML SDK Scenario Runner on the ML Emulation Layer for Vulkan®:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PR is introducing caching to minimize the time taken to build.

Both ccache and github actions caching are enabled to save build time:

- ccache (sccache on Windows): Reuses previous compilation results.
- GitHub Actions cache: Reuses cached files across CI runs.
- GitHub Actions cache saves and restores the ccache cache between CI runs.

**Build Time Improvement **

**Before Caching** : https://github.com/sherlokdev/ai-ml-sdk-for-vulkan/actions/runs/28087493364
**After Caching** : https://github.com/sherlokdev/ai-ml-sdk-for-vulkan/actions/runs/28328924480

| Platform             | Before Caching   | After Caching |
|-----------------|------------------|---------------|
| Linux (Arm64)   | ~1 h                      | ~8 m               |
| Linux (x86_64)  | ~1 h 15 m             | ~9 m               |
| macOS               | ~1 h                      | ~10-13 m        |
| Windows            | ~2 h 30 m            | ~20-23 m       |


Summary of code changes done in the PR:
```
- enable ccache and github action/cache for linux/macos and sccache for windows
- always store the latest cache by add the CI run id to each stored cache
```