### PR TITLE
Enable compiler caching for SDK build

### DIFF
--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -79,10 +79,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ runner.os }}-${{ matrix.arch_tag }}-${{ github.sha }}-${{ github.run_id }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
           restore-keys: |
-            sccache-${{ runner.os }}-${{ matrix.arch_tag }}-${{ github.sha }}-
-            sccache-${{ runner.os }}-${{ matrix.arch_tag }}-
+            ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh
@@ -128,9 +127,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/Library/Caches/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-${{ github.run_id }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
           restore-keys: |
-            ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-
             ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone repositories and build
@@ -193,9 +191,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~\AppData\Local\Mozilla\sccache
-          key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-${{ github.run_id }}
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
           restore-keys: |
-            sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-
             sccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run CI build script

--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /home/$user/.local/bin/sccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
@@ -122,7 +122,7 @@ jobs:
         run: brew install ccache
 
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
@@ -186,7 +186,7 @@ jobs:
           sccache --version
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~\AppData\Local\Mozilla\sccache
           key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}

--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -72,6 +72,15 @@ jobs:
 
       - &checkout
         uses: actions/checkout@v6
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: /home/$user/.local/bin/sccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh
 
@@ -108,6 +117,17 @@ jobs:
         run: |
           brew install molten-vk vulkan-tools vulkan-headers vulkan-loader
           echo "VK_DRIVER_FILES=$(brew --prefix molten-vk)/etc/vulkan/icd.d/MoltenVK_icd.json" >> $GITHUB_ENV
+
+      - name: Install ccache
+        run: brew install ccache
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh
@@ -158,6 +178,20 @@ jobs:
         shell: pwsh
         run: |
           git clone https://gerrit.googlesource.com/git-repo
+
+      - name: Install sccache # https://github.com/mozilla/sccache
+        shell: pwsh
+        run: |
+          choco install -y sccache
+          sccache --version
+
+      - name: Cache sccache
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Local\Mozilla\sccache
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            sccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run CI build script
         shell: pwsh

--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -27,7 +27,7 @@ jobs:
   build-linux:
     runs-on: ${{ matrix.platform }}
     env:
-      SCCACHE_DIR: $HOME/.local/bin/sccache
+      SCCACHE_DIR: /root/.cache/sccache
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -79,9 +79,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
           restore-keys: |
-            ccache-${{ runner.os }}-${{ runner.arch }}-
+            sccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh

--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -26,6 +26,8 @@ env:
 jobs:
   build-linux:
     runs-on: ${{ matrix.platform }}
+    env:
+      SCCACHE_DIR: /root/.cache/sccache
     strategy:
       matrix:
         include:
@@ -76,10 +78,11 @@ jobs:
       - name: Cache sccache
         uses: actions/cache@v6
         with:
-          path: /home/$user/.local/bin/sccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-${{ runner.os }}-${{ matrix.arch_tag }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ccache-${{ runner.os }}-${{ runner.arch }}-
+            sccache-${{ runner.os }}-${{ matrix.arch_tag }}-${{ github.sha }}-
+            sccache-${{ runner.os }}-${{ matrix.arch_tag }}-
 
       - name: Clone repositories and build
         run: .github/workflows/scripts/ci_build.sh
@@ -125,8 +128,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/Library/Caches/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-
             ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone repositories and build
@@ -189,8 +193,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~\AppData\Local\Mozilla\sccache
-          key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}-
             sccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run CI build script

--- a/.github/workflows/build-with-manifest.yml
+++ b/.github/workflows/build-with-manifest.yml
@@ -27,7 +27,7 @@ jobs:
   build-linux:
     runs-on: ${{ matrix.platform }}
     env:
-      SCCACHE_DIR: /root/.cache/sccache
+      SCCACHE_DIR: $HOME/.local/bin/sccache
     strategy:
       matrix:
         include:

--- a/.github/workflows/scripts/ci_build.ps1
+++ b/.github/workflows/scripts/ci_build.ps1
@@ -142,6 +142,13 @@ try {
 
     $env:VK_INSTANCE_LAYERS = "VK_LAYER_ML_Graph_Emulation;VK_LAYER_ML_Tensor_Emulation"
 
+    # Set the sccache cache directory (matches the GitHub Actions cache path)
+    $env:SCCACHE_DIR = "$env:LOCALAPPDATA\Mozilla\sccache"
+    $env:CMAKE_C_COMPILER_LAUNCHER = "sccache"
+    $env:CMAKE_CXX_COMPILER_LAUNCHER = "sccache"
+
+    sccache --zero-stats || $true
+
     Write-Host "Build VGF-Lib"
     python "./sw/vgf-lib/scripts/build.py" -j $cores --test
 
@@ -156,6 +163,8 @@ try {
 
     Write-Host "Build SDK Root"
     python "./scripts/build.py" -j $cores
+
+    sccache --show-stats || $true
 }
 finally {
     Pop-Location

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -119,13 +119,22 @@ if [[ "$(uname)" == "Darwin" ]]; then
   export CCACHE_DIR="$HOME/Library/Caches/ccache"
 else
   CACHE_TOOL="sccache"
-  export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cache/sccache}"
+  export SCCACHE_DIR="${SCCACHE_DIR:-/root/.cache/sccache}"
 fi
 
-mkdir -p "${CCACHE_DIR:-$SCCACHE_DIR}"
 
-# Ensure locally installed tools are found (e.g. sccache in the Docker image)
-export PATH="$HOME/.local/bin:$PATH"
+if [[ "$(uname)" == "Darwin" ]]; then
+  CACHE_TOOL="ccache"
+  export CCACHE_DIR="$HOME/Library/Caches/ccache"
+  mkdir -p "$CCACHE_DIR"
+else
+  CACHE_TOOL="sccache"
+  export SCCACHE_DIR="${SCCACHE_DIR:-/root/.cache/sccache}"
+  mkdir -p "$SCCACHE_DIR"
+
+  # Ensure locally installed tools are found (e.g. sccache in the Docker image)
+  export PATH="/home/mlsdkuser/.local/bin:$PATH"
+fi
 
 export CMAKE_C_COMPILER_LAUNCHER="$CACHE_TOOL"
 export CMAKE_CXX_COMPILER_LAUNCHER="$CACHE_TOOL"

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -115,18 +115,22 @@ run_checks() {
 }
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  export SCCACHE_DIR="$HOME/Library/Caches/sccache"
+  CACHE_TOOL="ccache"
+  export CCACHE_DIR="$HOME/Library/Caches/ccache"
 else
+  CACHE_TOOL="sccache"
   export SCCACHE_DIR="$HOME/.cache/sccache"
 fi
 
-mkdir -p "$SCCACHE_DIR"
+mkdir -p "${CCACHE_DIR:-$SCCACHE_DIR}"
 
-export CMAKE_C_COMPILER_LAUNCHER=sccache
-export CMAKE_CXX_COMPILER_LAUNCHER=sccache
+# Ensure locally installed tools are found (e.g. sccache in the Docker image)
+export PATH="$HOME/.local/bin:$PATH"
 
-sccache --zero-stats || true
+export CMAKE_C_COMPILER_LAUNCHER="$CACHE_TOOL"
+export CMAKE_CXX_COMPILER_LAUNCHER="$CACHE_TOOL"
 
+"$CACHE_TOOL" --zero-stats || true
 echo "Build VGF-Lib"
 run_checks ./sw/vgf-lib
 ./sw/vgf-lib/scripts/build.py -j $(nproc) --doc --test
@@ -151,6 +155,6 @@ echo "Build SDK Root"
 run_checks .
 ./scripts/build.py -j $(nproc) --doc
 
-sccache --show-stats || true
+"$CACHE_TOOL" --show-stats || true
 
 popd

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -119,7 +119,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   export CCACHE_DIR="$HOME/Library/Caches/ccache"
 else
   CACHE_TOOL="sccache"
-  export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cache/sccache}"
+  export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.local/bin/sccache}"
 fi
 
 mkdir -p "${CCACHE_DIR:-$SCCACHE_DIR}"

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -117,15 +117,6 @@ run_checks() {
 if [[ "$(uname)" == "Darwin" ]]; then
   CACHE_TOOL="ccache"
   export CCACHE_DIR="$HOME/Library/Caches/ccache"
-else
-  CACHE_TOOL="sccache"
-  export SCCACHE_DIR="${SCCACHE_DIR:-/root/.cache/sccache}"
-fi
-
-
-if [[ "$(uname)" == "Darwin" ]]; then
-  CACHE_TOOL="ccache"
-  export CCACHE_DIR="$HOME/Library/Caches/ccache"
   mkdir -p "$CCACHE_DIR"
 else
   CACHE_TOOL="sccache"

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -115,17 +115,17 @@ run_checks() {
 }
 
 if [[ "$(uname)" == "Darwin" ]]; then
-  export CCACHE_DIR="$HOME/Library/Caches/ccache"
+  export SCCACHE_DIR="$HOME/Library/Caches/sccache"
 else
-  export CCACHE_DIR="$HOME/.cache/ccache"
+  export SCCACHE_DIR="$HOME/.cache/sccache"
 fi
 
-mkdir -p "$CCACHE_DIR"
+mkdir -p "$SCCACHE_DIR"
 
-export CMAKE_C_COMPILER_LAUNCHER=ccache
-export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+export CMAKE_C_COMPILER_LAUNCHER=sccache
+export CMAKE_CXX_COMPILER_LAUNCHER=sccache
 
-ccache --zero-stats || true
+sccache --zero-stats || true
 
 echo "Build VGF-Lib"
 run_checks ./sw/vgf-lib
@@ -151,6 +151,6 @@ echo "Build SDK Root"
 run_checks .
 ./scripts/build.py -j $(nproc) --doc
 
-ccache --show-stats || true
+sccache --show-stats || true
 
 popd

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -119,7 +119,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   export CCACHE_DIR="$HOME/Library/Caches/ccache"
 else
   CACHE_TOOL="sccache"
-  export SCCACHE_DIR="$HOME/.cache/sccache"
+  export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cache/sccache}"
 fi
 
 mkdir -p "${CCACHE_DIR:-$SCCACHE_DIR}"
@@ -131,6 +131,7 @@ export CMAKE_C_COMPILER_LAUNCHER="$CACHE_TOOL"
 export CMAKE_CXX_COMPILER_LAUNCHER="$CACHE_TOOL"
 
 "$CACHE_TOOL" --zero-stats || true
+
 echo "Build VGF-Lib"
 run_checks ./sw/vgf-lib
 ./sw/vgf-lib/scripts/build.py -j $(nproc) --doc --test

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -114,6 +114,19 @@ run_checks() {
   popd
 }
 
+if [[ "$(uname)" == "Darwin" ]]; then
+  export CCACHE_DIR="$HOME/Library/Caches/ccache"
+else
+  export CCACHE_DIR="$HOME/.cache/ccache"
+fi
+
+mkdir -p "$CCACHE_DIR"
+
+export CMAKE_C_COMPILER_LAUNCHER=ccache
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+ccache --zero-stats || true
+
 echo "Build VGF-Lib"
 run_checks ./sw/vgf-lib
 ./sw/vgf-lib/scripts/build.py -j $(nproc) --doc --test
@@ -137,5 +150,7 @@ run_checks ./sw/scenario-runner
 echo "Build SDK Root"
 run_checks .
 ./scripts/build.py -j $(nproc) --doc
+
+ccache --show-stats || true
 
 popd

--- a/.github/workflows/scripts/ci_build.sh
+++ b/.github/workflows/scripts/ci_build.sh
@@ -119,7 +119,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   export CCACHE_DIR="$HOME/Library/Caches/ccache"
 else
   CACHE_TOOL="sccache"
-  export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.local/bin/sccache}"
+  export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cache/sccache}"
 fi
 
 mkdir -p "${CCACHE_DIR:-$SCCACHE_DIR}"


### PR DESCRIPTION
Enable caching to speed up builds.
Based on https://github.com/arm/ai-ml-sdk-for-vulkan/pull/150 and all credits to the author.